### PR TITLE
chore: replace deprecated `set-output`

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -475,7 +475,7 @@ export class MasonGitHubWorkflow extends PipelineBase {
     // we need the jobId to reference the outputs later
     this.assetHashMap[assetId] = jobId;
     fileContents.push(
-      `echo '::set-output name=${ASSET_HASH_NAME}::${assetId}'`,
+      `echo "${ASSET_HASH_NAME}=${assetId}" >> $GITHUB_OUTPUT`,
     );
 
     const publishStepFile = path.join(


### PR DESCRIPTION
`::set-output` is deprecated, this fixes it by replacing it with the `echo` statement as described at https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands